### PR TITLE
Catch up to VM changes

### DIFF
--- a/freebsd/cddl/usr.bin/mdb/modules/kernel/kernel.c
+++ b/freebsd/cddl/usr.bin/mdb/modules/kernel/kernel.c
@@ -973,16 +973,18 @@ static int
 kgrep_walk_uma_slab(uintptr_t addr, const void *data, void *private)
 {
 	kgrep_walk_data_t *kwd;
-	mdb_uma_slab_t slab;
 	uintptr_t start;
 
-	if (mdb_ctf_convert(&slab, "struct uma_slab", "mdb_uma_slab_t", data,
-	    0) == -1) {
+	/*
+	 * start is now found in a containing struct as uhs_data
+	 *  which immediately preceeds the slab.
+	*/
+	addr -= sizeof(uintptr_t);
+	if (mdb_ctf_vread(&start, "uintptr_t", "uintptr_t", addr, 0) == -1) {
 		mdb_warn("failed to parse struct uma_slab at %#lr", addr);
 		return (WALK_ERR);
 	}
 
-	start = (uintptr_t)slab.us_data;
 	kwd = private;
 	return (kwd->kg_cb(start, start + PAGE_SIZE, kwd->kg_cbdata));
 }

--- a/freebsd/cddl/usr.bin/mdb/modules/kernel/kernel.h
+++ b/freebsd/cddl/usr.bin/mdb/modules/kernel/kernel.h
@@ -95,7 +95,7 @@ typedef u_char objtype_t;
 #define MAP_ENTRY_IS_SUB_MAP		0x0002
 
 typedef struct {
-	struct vm_map_entry *next;
+	struct vm_map_entry *right;
 	uintptr_t start;
 	uintptr_t end;
 	union {
@@ -110,22 +110,22 @@ typedef struct {
 	objtype_t type;
 } mdb_vm_object_t;
 
-typedef struct {
-	LIST_HEAD(,uma_slab)	uk_part_slab;
-	LIST_HEAD(,uma_slab)	uk_free_slab;
-	LIST_HEAD(,uma_slab)	uk_full_slab;
 
+typedef struct {
+	LIST_HEAD(,uma_slab)	ud_part_slab;
+	LIST_HEAD(,uma_slab)	ud_free_slab;
+	LIST_HEAD(,uma_slab)	ud_full_slab;
+} mdb_uma_domain_t;
+
+typedef struct {
 	void *uk_allocf;
 
 	LIST_ENTRY(uma_keg)	uk_link;
+	mdb_uma_domain_t uk_domain[0];
 } mdb_uma_keg_t;
 
 typedef struct {
-	union {
-		LIST_ENTRY(uma_slab)	_us_link;
-		unsigned long	_us_size;
-	} us_type;
-	uint8_t		*us_data;
+	LIST_ENTRY(uma_slab)	us_link;
 } mdb_uma_slab_t;
 
 TAILQ_HEAD(pglist, vm_page);


### PR DESCRIPTION
- start is now found in a containing struct as uhs_data, not
	directly in the slab itself

- Rather than holding a pointer to the slab, the keg now
	holds an array of domains, which contain pointers
	to slabs.