### PR TITLE
sig2str: use system implementation starting with 1500047

### DIFF
--- a/freebsd/cddl/compat/opensolaris/include/signal.h
+++ b/freebsd/cddl/compat/opensolaris/include/signal.h
@@ -30,9 +30,10 @@
 #define	_OPENSOLARIS_SIGNAL_H_
 
 #include_next <signal.h>
-
+#ifndef SIG2STR_MAX
 #define	SIG2STR_MAX	64
 
 int	sig2str(int _signum, char *_str);
+#endif
 
 #endif /* _OPENSOLARIS_SIGNAL_H_ */

--- a/freebsd/cddl/usr.bin/mdb/mdb/Makefile
+++ b/freebsd/cddl/usr.bin/mdb/mdb/Makefile
@@ -7,6 +7,8 @@ LIBDISASM_DIR=	${CDDL_TOP}/usr/src/lib/libdisasm
 LIBSAVEARGS_DIR=${CDDL_TOP}/usr/src/lib/libsaveargs
 DIS_DIR=	${CDDL_TOP}/usr/src/common/dis
 
+OSVERSION!=	awk '/^\#define[[:blank:]]__FreeBSD_version/ {print $$3}' < /usr/include/sys/param.h
+
 PROG=	mdb
 MAN=
 
@@ -145,8 +147,10 @@ SRCS+=	mdb_lex.l \
 
 SRCS+=	\
 	fdwalk.c \
-	proc_str2sig.c \
-	sig2str.c
+	proc_str2sig.c
+.if ${OSVERSION} < 1500047
+SRCS+=	sig2str.c
+.endif
 
 # For the "sys/kern/syscalls.c" include.
 CFLAGS+= -I${FREEBSD_SRC_DIR}


### PR DESCRIPTION
In signal.h hide local definition if SIG2STR_MAX already seen.